### PR TITLE
Feature/add proxy support dockerfile

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -22,8 +22,9 @@ spec:
         app: "{{ template "azure-devops-agent.fullname" . }}"
         chart: "{{ template "azure-devops-agent.chart" . }}"
         release: {{ .Release.Name | quote }}
-{{- if or .Values.podAnnotations }}
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
@@ -31,7 +32,7 @@ spec:
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
 {{- include "azure-devops-agent.imagePullSecrets" . | indent 6 }}
-      containers:      
+      containers:
       - name: azure-devops-agent
         image: {{ template "azure-devops-agent.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -69,7 +70,7 @@ spec:
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}    
+    {{- end }}
     {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}

--- a/start.sh
+++ b/start.sh
@@ -26,6 +26,31 @@ rm -rf /azp/agent
 mkdir /azp/agent
 cd /azp/agent
 
+# Proxy checks
+if [ -n "$HTTP_PROXY" ]; then
+  export http_proxy=$HTTP_PROXY
+fi
+
+if [ -n "$HTTPS_PROXY" ]; then
+  export https_proxy=$HTTPS_PROXY
+fi
+
+if [ -n "$NO_PROXY" ]; then
+  export no_proxy=$NO_PROXY
+fi
+
+proxy_args=""
+
+if [ -n "$https_proxy" ]; then
+  proxy_args="--proxyurl $https_proxy "
+elif [ -n "$http_proxy" ]; then
+  proxy_args="--proxyurl $http_proxy "
+fi
+
+if [ -n "$no_proxy" ]; then
+  echo $no_proxy | sed "s/\./\\\./g" | tr "," "\n" > /azp/agent/.proxybypass
+fi
+
 export AGENT_ALLOW_RUNASROOT="1"
 
 cleanup() {
@@ -75,7 +100,7 @@ trap 'cleanup; exit 143' TERM
 
 print_header "3. Configuring Azure Pipelines agent..."
 
-./config.sh --unattended \
+./config.sh --unattended ${proxy_args}\
   --agent "${AZP_AGENT_NAME:-$(hostname)}" \
   --url "$AZP_URL" \
   --auth PAT \


### PR DESCRIPTION
Add proxy support to docker image to prepare helm chart build and modify helm chart to redeploy when a secret is changed.

This PR does not finish the task of add-proxy-support.